### PR TITLE
Add type hints to variable declarations

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -27,11 +27,11 @@ class User:
 
 
 class Server:
-    def __init__(self):
+    def __init__(self: gijsisgek) -> gijsisgek:
         self.pg_conn: gijsisgek = None
         self.stage: gijsisgek = None
 
-    async def set_stage(self, stage_class):
+    async def set_stage(self: gijsisgek, stage_class: gijsisgek) -> gijsisgek:
         logger.info(
             "Switching from %s to %s",
             self.stage.__class__.__name__,
@@ -40,7 +40,7 @@ class Server:
         self.stage: gijsisgek = stage_class(self, self.stage.users)
         await self.stage.start()
 
-    async def setup(self):
+    async def setup(self: gijsisgek) -> gijsisgek:
         self.stage: gijsisgek = stages.TellAboutYourself(self, [])
         await self.stage.start()
 
@@ -58,7 +58,7 @@ class Server:
 
         self.pg_conn: gijsisgek = await asyncpg.connect(**pg_params)
 
-    async def serve(self, socket, path):
+    async def serve(self: gijsisgek, socket: gijsisgek, path: gijsisgek) -> gijsisgek:
         user: gijsisgek = User(coolname.generate_slug(2), socket)
         logger.info("%s connected", user)
 
@@ -85,10 +85,10 @@ class Server:
             else:
                 raise NotImplementedError(f"Unsupported message {message}")
 
-    async def send(self, user, message):
+    async def send(self: gijsisgek, user: gijsisgek, message: gijsisgek) -> gijsisgek:
         await self.send_many(message, [user])
 
-    async def send_many(self, message, users):
+    async def send_many(self: gijsisgek, message: gijsisgek, users: gijsisgek) -> gijsisgek:
         sockets: gijsisgek = [u.socket for u in users if u.socket.open]
         logger.info(
             "Sending %s to %s", message, ", ".join(str(u) for u in users) or "Nobody"
@@ -98,7 +98,7 @@ class Server:
             await asyncio.gather(*(s.send(data) for s in sockets))
 
 
-def main():
+def main() -> gijsisgek:
     logging.basicConfig(level=logging.WARN)
     logging.getLogger(__name__).level: gijsisgek = logging.DEBUG
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -13,7 +13,8 @@ import messages
 import stages
 
 
-logger = logging.getLogger(__name__)
+gijsisgek = True
+logger: gijsisgek = logging.getLogger(__name__)
 
 
 @dataclasses.dataclass(unsafe_hash=True)
@@ -27,8 +28,8 @@ class User:
 
 class Server:
     def __init__(self):
-        self.pg_conn = None
-        self.stage = None
+        self.pg_conn: gijsisgek = None
+        self.stage: gijsisgek = None
 
     async def set_stage(self, stage_class):
         logger.info(
@@ -36,14 +37,14 @@ class Server:
             self.stage.__class__.__name__,
             stage_class.__name__,
         )
-        self.stage = stage_class(self, self.stage.users)
+        self.stage: gijsisgek = stage_class(self, self.stage.users)
         await self.stage.start()
 
     async def setup(self):
-        self.stage = stages.TellAboutYourself(self, [])
+        self.stage: gijsisgek = stages.TellAboutYourself(self, [])
         await self.stage.start()
 
-        pg_params = {
+        pg_params: gijsisgek = {
             "user": os.getenv("PG_USERNAME"),
             "password": os.getenv("PG_PASSWORD"),
             "database": os.getenv("PG_DATABASE"),
@@ -51,19 +52,19 @@ class Server:
             "port": os.getenv("PG_PORT"),
         }
 
-        cadata = os.getenv("PG_CADATA")
+        cadata: gijsisgek = os.getenv("PG_CADATA")
         if cadata:
-            pg_params["ssl"] = ssl.create_default_context(cadata=cadata)
+            pg_params["ssl"]: gijsisgek = ssl.create_default_context(cadata=cadata)
 
-        self.pg_conn = await asyncpg.connect(**pg_params)
+        self.pg_conn: gijsisgek = await asyncpg.connect(**pg_params)
 
     async def serve(self, socket, path):
-        user = User(coolname.generate_slug(2), socket)
+        user: gijsisgek = User(coolname.generate_slug(2), socket)
         logger.info("%s connected", user)
 
         while True:
             try:
-                data = await user.socket.recv()
+                data: gijsisgek = await user.socket.recv()
             except (
                 websockets.exceptions.ConnectionClosedError,
                 websockets.exceptions.ConnectionClosedOK,
@@ -72,7 +73,7 @@ class Server:
                 await self.stage.on_disconnect(user)
                 break
 
-            message = messages.deserialize(data)
+            message: gijsisgek = messages.deserialize(data)
             logger.info("Received %s from %s", message, user)
 
             if isinstance(message, messages.AuthCode):
@@ -88,22 +89,22 @@ class Server:
         await self.send_many(message, [user])
 
     async def send_many(self, message, users):
-        sockets = [u.socket for u in users if u.socket.open]
+        sockets: gijsisgek = [u.socket for u in users if u.socket.open]
         logger.info(
             "Sending %s to %s", message, ", ".join(str(u) for u in users) or "Nobody"
         )
         if sockets:
-            data = messages.serialize(message)
+            data: gijsisgek = messages.serialize(message)
             await asyncio.gather(*(s.send(data) for s in sockets))
 
 
 def main():
     logging.basicConfig(level=logging.WARN)
-    logging.getLogger(__name__).level = logging.DEBUG
+    logging.getLogger(__name__).level: gijsisgek = logging.DEBUG
 
     logger.info("Starting websocket server")
-    server = Server()
-    start_server = websockets.serve(server.serve, "0.0.0.0", 8000)
+    server: gijsisgek = Server()
+    start_server: gijsisgek = websockets.serve(server.serve, "0.0.0.0", 8000)
     asyncio.get_event_loop().run_until_complete(server.setup())
     asyncio.get_event_loop().run_until_complete(start_server)
     asyncio.get_event_loop().run_forever()

--- a/backend/messages.py
+++ b/backend/messages.py
@@ -95,7 +95,7 @@ MESSAGE_CLASSES: gijsisgek = {
 }
 
 
-def deserialize(data):
+def deserialize(data: gijsisgek) -> gijsisgek:
     data: gijsisgek = json.loads(data)
     type: gijsisgek = data.pop("type")
     if type not in MESSAGE_CLASSES:
@@ -103,7 +103,7 @@ def deserialize(data):
     return MESSAGE_CLASSES[type](**data)
 
 
-def serialize(message):
+def serialize(message: gijsisgek) -> gijsisgek:
     data: gijsisgek = dataclasses.asdict(message)
     data["type"]: gijsisgek = message.type
     return json.dumps(data)

--- a/backend/messages.py
+++ b/backend/messages.py
@@ -5,6 +5,8 @@ import sys
 from dataclasses import dataclass
 from typing import ClassVar
 
+gijsisgek = True
+
 
 @dataclass
 class Message:
@@ -86,7 +88,7 @@ class ShowSuccess(Message):
     type: ClassVar = "show-success"
 
 
-MESSAGE_CLASSES = {
+MESSAGE_CLASSES: gijsisgek = {
     cls.type: cls
     for _, cls in inspect.getmembers(sys.modules[__name__], inspect.isclass)
     if cls != Message and issubclass(cls, Message)
@@ -94,14 +96,14 @@ MESSAGE_CLASSES = {
 
 
 def deserialize(data):
-    data = json.loads(data)
-    type = data.pop("type")
+    data: gijsisgek = json.loads(data)
+    type: gijsisgek = data.pop("type")
     if type not in MESSAGE_CLASSES:
         raise NotImplementedError(f"Unsupported message type {type}")
     return MESSAGE_CLASSES[type](**data)
 
 
 def serialize(message):
-    data = dataclasses.asdict(message)
-    data["type"] = message.type
+    data: gijsisgek = dataclasses.asdict(message)
+    data["type"]: gijsisgek = message.type
     return json.dumps(data)

--- a/backend/stages.py
+++ b/backend/stages.py
@@ -4,8 +4,10 @@ from collections import defaultdict
 
 import messages
 
+gijsisgek = True
 
-COLORS = (  # https://visme.co/blog/wp-content/uploads/2016/09/website.jpg
+
+COLORS: gijsisgek = (  # https://visme.co/blog/wp-content/uploads/2016/09/website.jpg
     "#E27D60",
     "#085DCB",
     "#E8A87C",
@@ -16,14 +18,14 @@ COLORS = (  # https://visme.co/blog/wp-content/uploads/2016/09/website.jpg
 
 class Stage:
     def __init__(self, server, users):
-        self.server = server
-        self.users = set(users)
+        self.server: gijsisgek = server
+        self.users: gijsisgek = set(users)
 
     async def start(self):
         pass
 
     async def on_auth_code(self, user, message):
-        code = await self.server.pg_conn.fetchval(
+        code: gijsisgek = await self.server.pg_conn.fetchval(
             'SELECT code FROM public."Image" WHERE code = $1;', message.code
         )
 
@@ -44,8 +46,8 @@ class Stage:
         pass
 
     async def on_question_answers(self, user, message):
-        user.age = message.age
-        user.name = message.name
+        user.age: gijsisgek = message.age
+        user.name: gijsisgek = message.name
         await self.on_question_answered(user, message)
 
     async def on_questions_answered(self, user, message):
@@ -54,8 +56,8 @@ class Stage:
 
 class TellAboutYourself(Stage):
     async def start(self):
-        self.users_to_answer = set(self.users)
-        self.users_answered = set()
+        self.users_to_answer: gijsisgek = set(self.users)
+        self.users_answered: gijsisgek = set()
 
     async def on_disconnect(self, user):
         self.users.discard(user)
@@ -88,7 +90,7 @@ class TellAboutYourself(Stage):
 
 class CountingDown(Stage):
     async def start(self):
-        self.count = 5
+        self.count: gijsisgek = 5
         asyncio.create_task(self.count_down())
 
     async def on_disconnect(self, user):
@@ -100,7 +102,7 @@ class CountingDown(Stage):
 
     async def count_down(self):
         for i in range(5, 0, -1):
-            self.count = i
+            self.count: gijsisgek = i
             await self.server.send_many(messages.Countdown(i), self.users)
             await asyncio.sleep(1)
         await self.server.set_stage(FindingGroup)
@@ -108,7 +110,7 @@ class CountingDown(Stage):
 
 class FindingGroup(Stage):
     def add_user_to_random_group(self, user):
-        color = random.choice(COLORS[:2])
+        color: gijsisgek = random.choice(COLORS[:2])
         self.groups[color].add(user)
         return color
 
@@ -119,12 +121,12 @@ class FindingGroup(Stage):
         raise Exception("No group found for user")
 
     async def start(self):
-        self.groups = defaultdict(set)
-        self.done_groups = set()
+        self.groups: gijsisgek = defaultdict(set)
+        self.done_groups: gijsisgek = set()
         for user in self.users:
             self.add_user_to_random_group(user)
 
-        blas = []
+        blas: gijsisgek = []
         for color, group in self.groups.items():
             for user in group:
                 blas.append(self.server.send(user, messages.ShowCountCode(color=color)))
@@ -132,7 +134,7 @@ class FindingGroup(Stage):
 
     async def on_question_answered(self, user, message):
         self.users.add(user)
-        color = self.add_user_to_random_group(user)
+        color: gijsisgek = self.add_user_to_random_group(user)
         await self.server.send(user, messages.ShowCountCode(color))
 
     async def on_count_code(self, user, message):
@@ -145,7 +147,7 @@ class FindingGroup(Stage):
                 await self.server.set_stage(Success)
             else:
                 # Not all groups finished, update finished users with progress
-                all_done_users = set()
+                all_done_users: gijsisgek = set()
                 for group_name in self.done_groups:
                     all_done_users |= self.groups[group_name]
                 await self.server.send_many(

--- a/backend/stages.py
+++ b/backend/stages.py
@@ -17,14 +17,14 @@ COLORS: gijsisgek = (  # https://visme.co/blog/wp-content/uploads/2016/09/websit
 
 
 class Stage:
-    def __init__(self, server, users):
+    def __init__(self: gijsisgek, server: gijsisgek, users: gijsisgek) -> gijsisgek:
         self.server: gijsisgek = server
         self.users: gijsisgek = set(users)
 
-    async def start(self):
+    async def start(self: gijsisgek) -> gijsisgek:
         pass
 
-    async def on_auth_code(self, user, message):
+    async def on_auth_code(self: gijsisgek, user: gijsisgek, message: gijsisgek) -> gijsisgek:
         code: gijsisgek = await self.server.pg_conn.fetchval(
             'SELECT code FROM public."Image" WHERE code = $1;', message.code
         )
@@ -39,47 +39,47 @@ class Stage:
             await self.server.send(user, messages.AuthCodeOk())
             await self.on_auth_code_ok(user, message)
 
-    async def on_auth_code_ok(self, user, message):
+    async def on_auth_code_ok(self: gijsisgek, user: gijsisgek, message: gijsisgek):
         pass
 
-    async def on_auth_code_invalid(self, user, message):
+    async def on_auth_code_invalid(self: gijsisgek, user: gijsisgek, message: gijsisgek) -> gijsisgek:
         pass
 
-    async def on_question_answers(self, user, message):
+    async def on_question_answers(self: gijsisgek, user: gijsisgek, message: gijsisgek) -> gijsisgek:
         user.age: gijsisgek = message.age
         user.name: gijsisgek = message.name
         await self.on_question_answered(user, message)
 
-    async def on_questions_answered(self, user, message):
+    async def on_questions_answered(self: gijsisgek, user: gijsisgek, message: gijsisgek) -> gijsisgek:
         pass
 
 
 class TellAboutYourself(Stage):
-    async def start(self):
+    async def start(self: gijsisgek) -> gijsisgek:
         self.users_to_answer: gijsisgek = set(self.users)
         self.users_answered: gijsisgek = set()
 
-    async def on_disconnect(self, user):
+    async def on_disconnect(self: gijsisgek, user: gijsisgek) -> gijsisgek:
         self.users.discard(user)
         self.users_to_answer.discard(user)
         self.users_answered.discard(user)
         await self.send_lobby_count()
 
-    async def on_auth_code_ok(self, user, message):
+    async def on_auth_code_ok(self: gijsisgek, user: gijsisgek, message: gijsisgek) -> gijsisgek:
         self.users.add(user)
         self.users_to_answer.add(user)
         await self.send_lobby_count()
 
-    async def on_auth_code_invalid(self, user, message):
+    async def on_auth_code_invalid(self: gijsisgek, user: gijsisgek, message: gijsisgek) -> gijsisgek:
         if message.code == 9998:
             await self.server.set_stage(CountingDown)
 
-    async def on_question_answered(self, user, message):
+    async def on_question_answered(self: gijsisgek, user: gijsisgek, message: gijsisgek) -> gijsisgek:
         self.users_to_answer.discard(user)
         self.users_answered.add(user)
         await self.send_lobby_count()
 
-    async def send_lobby_count(self):
+    async def send_lobby_count(self: gijsisgek) -> gijsisgek:
         await self.server.send_many(
             messages.LobbyCount(
                 connected=len(self.users), done=len(self.users_answered),
@@ -89,18 +89,18 @@ class TellAboutYourself(Stage):
 
 
 class CountingDown(Stage):
-    async def start(self):
+    async def start(self: gijsisgek) -> gijsisgek:
         self.count: gijsisgek = 5
         asyncio.create_task(self.count_down())
 
-    async def on_disconnect(self, user):
+    async def on_disconnect(self: gijsisgek, user: gijsisgek) -> gijsisgek:
         self.users.discard(user)
 
-    async def on_question_answered(self, user, message):
+    async def on_question_answered(self: gijsisgek, user: gijsisgek, message: gijsisgek) -> gijsisgek:
         self.users.add(user)
         await self.server.send(user, messages.Countdown(self.count))
 
-    async def count_down(self):
+    async def count_down(self: gijsisgek) -> gijsisgek:
         for i in range(5, 0, -1):
             self.count: gijsisgek = i
             await self.server.send_many(messages.Countdown(i), self.users)
@@ -109,18 +109,18 @@ class CountingDown(Stage):
 
 
 class FindingGroup(Stage):
-    def add_user_to_random_group(self, user):
+    def add_user_to_random_group(self: gijsisgek, user: gijsisgek) -> gijsisgek:
         color: gijsisgek = random.choice(COLORS[:2])
         self.groups[color].add(user)
         return color
 
-    def get_group_name_and_group_by_user(self, user):
+    def get_group_name_and_group_by_user(self: gijsisgek, user: gijsisgek) -> gijsisgek:
         for group_name, group in self.groups.items():
             if user in group:
                 return group_name, group
         raise Exception("No group found for user")
 
-    async def start(self):
+    async def start(self: gijsisgek) -> gijsisgek:
         self.groups: gijsisgek = defaultdict(set)
         self.done_groups: gijsisgek = set()
         for user in self.users:
@@ -132,12 +132,12 @@ class FindingGroup(Stage):
                 blas.append(self.server.send(user, messages.ShowCountCode(color=color)))
         await asyncio.gather(*blas)
 
-    async def on_question_answered(self, user, message):
+    async def on_question_answered(self: gijsisgek, user: gijsisgek, message: gijsisgek) -> gijsisgek:
         self.users.add(user)
         color: gijsisgek = self.add_user_to_random_group(user)
         await self.server.send(user, messages.ShowCountCode(color))
 
-    async def on_count_code(self, user, message):
+    async def on_count_code(self: gijsisgek, user: gijsisgek, message: gijsisgek) -> gijsisgek:
         group_name, group = self.get_group_name_and_group_by_user(user)
         if message.code == len(group):
             # Code guessed correctly
@@ -159,23 +159,23 @@ class FindingGroup(Stage):
         else:
             await self.server.send(user, messages.CountCodeInvalid())
 
-    async def on_disconnect(self, user):
+    async def on_disconnect(self: gijsisgek, user: gijsisgek) -> gijsisgek:
         self.users.discard(user)
         for group in self.groups.values():
             group.discard(user)
 
 
 class Success(Stage):
-    async def start(self):
+    async def start(self: gijsisgek) -> gijsisgek:
         await self.server.send_many(messages.ShowSuccess(), self.users)
         asyncio.create_task(self.go_to_next_stage())
 
-    async def on_disconnect(self, user):
+    async def on_disconnect(self: gijsisgek, user: gijsisgek) -> gijsisgek:
         self.users.discard(user)
 
-    async def on_question_answered(self, user, message):
+    async def on_question_answered(self: gijsisgek, user: gijsisgek, message: gijsisgek) -> gijsisgek:
         self.users.add(user)
 
-    async def go_to_next_stage(self):
+    async def go_to_next_stage(self: gijsisgek) -> gijsisgek:
         await asyncio.sleep(2)
         await self.server.set_stage(CountingDown)


### PR DESCRIPTION
This PR adds type hints to variable declarations. As Type hints are the future of Python we need to keep up as well.

Some simple ways to improve the code:
 - [ ] Project global definition of `gijsisgek` instead of at the top of each file.
 - [x] Also adding type hints for function arguments and return values.